### PR TITLE
Added basic description for relases

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -32,105 +32,120 @@
     </item>
     <item>
       <title>Released nodejs/caritat v0.6.2</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/caritat v0.6.2 by github-actions[bot]. <a href="https://github.com/nodejs/caritat/releases/tag/v0.6.2">More details</a></p>
+]]></description>
       <pubDate>Tue, 13 Jun 2023 16:22:00 GMT</pubDate>
       <link>https://github.com/nodejs/caritat/releases/tag/v0.6.2</link>
       <guid>https://github.com/nodejs/caritat/releases/tag/v0.6.2</guid>
     </item>
     <item>
       <title>Released nodejs/caritat v0.6.1</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/caritat v0.6.1 by github-actions[bot]. <a href="https://github.com/nodejs/caritat/releases/tag/v0.6.1">More details</a></p>
+]]></description>
       <pubDate>Tue, 13 Jun 2023 16:10:00 GMT</pubDate>
       <link>https://github.com/nodejs/caritat/releases/tag/v0.6.1</link>
       <guid>https://github.com/nodejs/caritat/releases/tag/v0.6.1</guid>
     </item>
     <item>
       <title>Released nodejs/caritat v0.6.0</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/caritat v0.6.0 by github-actions[bot]. <a href="https://github.com/nodejs/caritat/releases/tag/v0.6.0">More details</a></p>
+]]></description>
       <pubDate>Tue, 13 Jun 2023 15:38:00 GMT</pubDate>
       <link>https://github.com/nodejs/caritat/releases/tag/v0.6.0</link>
       <guid>https://github.com/nodejs/caritat/releases/tag/v0.6.0</guid>
     </item>
     <item>
       <title>Released nodejs/corepack v0.19.0</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/corepack v0.19.0 by github-actions[bot]. <a href="https://github.com/nodejs/corepack/releases/tag/v0.19.0">More details</a></p>
+]]></description>
       <pubDate>Sat, 24 Jun 2023 16:55:00 GMT</pubDate>
       <link>https://github.com/nodejs/corepack/releases/tag/v0.19.0</link>
       <guid>https://github.com/nodejs/corepack/releases/tag/v0.19.0</guid>
     </item>
     <item>
       <title>Released nodejs/corepack v0.18.1</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/corepack v0.18.1 by github-actions[bot]. <a href="https://github.com/nodejs/corepack/releases/tag/v0.18.1">More details</a></p>
+]]></description>
       <pubDate>Tue, 13 Jun 2023 12:56:00 GMT</pubDate>
       <link>https://github.com/nodejs/corepack/releases/tag/v0.18.1</link>
       <guid>https://github.com/nodejs/corepack/releases/tag/v0.18.1</guid>
     </item>
     <item>
       <title>Released nodejs/llhttp release/v8.1.1</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/llhttp release/v8.1.1 by ShogunPanda. <a href="https://github.com/nodejs/llhttp/releases/tag/release/v8.1.1">More details</a></p>
+]]></description>
       <pubDate>Wed, 21 Jun 2023 08:07:00 GMT</pubDate>
       <link>https://github.com/nodejs/llhttp/releases/tag/release/v8.1.1</link>
       <guid>https://github.com/nodejs/llhttp/releases/tag/release/v8.1.1</guid>
     </item>
     <item>
       <title>Released nodejs/llhttp release/v6.0.11</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/llhttp release/v6.0.11 by ShogunPanda. <a href="https://github.com/nodejs/llhttp/releases/tag/release/v6.0.11">More details</a></p>
+]]></description>
       <pubDate>Wed, 21 Jun 2023 08:45:00 GMT</pubDate>
       <link>https://github.com/nodejs/llhttp/releases/tag/release/v6.0.11</link>
       <guid>https://github.com/nodejs/llhttp/releases/tag/release/v6.0.11</guid>
     </item>
     <item>
       <title>Released nodejs/node v20.3.1</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/node v20.3.1 by RafaelGSS. <a href="https://github.com/nodejs/node/releases/tag/v20.3.1">More details</a></p>
+]]></description>
       <pubDate>Tue, 20 Jun 2023 20:15:00 GMT</pubDate>
       <link>https://github.com/nodejs/node/releases/tag/v20.3.1</link>
       <guid>https://github.com/nodejs/node/releases/tag/v20.3.1</guid>
     </item>
     <item>
       <title>Released nodejs/node v18.16.1</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/node v18.16.1 by RafaelGSS. <a href="https://github.com/nodejs/node/releases/tag/v18.16.1">More details</a></p>
+]]></description>
       <pubDate>Tue, 20 Jun 2023 20:35:00 GMT</pubDate>
       <link>https://github.com/nodejs/node/releases/tag/v18.16.1</link>
       <guid>https://github.com/nodejs/node/releases/tag/v18.16.1</guid>
     </item>
     <item>
       <title>Released nodejs/node v16.20.1</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/node v16.20.1 by RafaelGSS. <a href="https://github.com/nodejs/node/releases/tag/v16.20.1">More details</a></p>
+]]></description>
       <pubDate>Tue, 20 Jun 2023 19:29:00 GMT</pubDate>
       <link>https://github.com/nodejs/node/releases/tag/v16.20.1</link>
       <guid>https://github.com/nodejs/node/releases/tag/v16.20.1</guid>
     </item>
     <item>
       <title>Released nodejs/node v20.3.0</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/node v20.3.0 by RafaelGSS. <a href="https://github.com/nodejs/node/releases/tag/v20.3.0">More details</a></p>
+]]></description>
       <pubDate>Thu, 08 Jun 2023 16:34:00 GMT</pubDate>
       <link>https://github.com/nodejs/node/releases/tag/v20.3.0</link>
       <guid>https://github.com/nodejs/node/releases/tag/v20.3.0</guid>
     </item>
     <item>
       <title>Released nodejs/node-addon-api v7.0.0</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/node-addon-api v7.0.0 by KevinEady. <a href="https://github.com/nodejs/node-addon-api/releases/tag/v7.0.0">More details</a></p>
+]]></description>
       <pubDate>Fri, 16 Jun 2023 21:19:00 GMT</pubDate>
       <link>https://github.com/nodejs/node-addon-api/releases/tag/v7.0.0</link>
       <guid>https://github.com/nodejs/node-addon-api/releases/tag/v7.0.0</guid>
     </item>
     <item>
       <title>Released nodejs/node-core-utils v3.2.0</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/node-core-utils v3.2.0 by github-actions[bot]. <a href="https://github.com/nodejs/node-core-utils/releases/tag/v3.2.0">More details</a></p>
+]]></description>
       <pubDate>Mon, 26 Jun 2023 06:12:00 GMT</pubDate>
       <link>https://github.com/nodejs/node-core-utils/releases/tag/v3.2.0</link>
       <guid>https://github.com/nodejs/node-core-utils/releases/tag/v3.2.0</guid>
     </item>
     <item>
       <title>Released nodejs/node-core-utils v3.1.0</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/node-core-utils v3.1.0 by github-actions[bot]. <a href="https://github.com/nodejs/node-core-utils/releases/tag/v3.1.0">More details</a></p>
+]]></description>
       <pubDate>Mon, 12 Jun 2023 06:32:00 GMT</pubDate>
       <link>https://github.com/nodejs/node-core-utils/releases/tag/v3.1.0</link>
       <guid>https://github.com/nodejs/node-core-utils/releases/tag/v3.1.0</guid>
     </item>
     <item>
       <title>Released nodejs/node-gyp v9.4.0</title>
-      <description></description>
+      <description><![CDATA[<p>Released nodejs/node-gyp v9.4.0 by github-actions[bot]. <a href="https://github.com/nodejs/node-gyp/releases/tag/v9.4.0">More details</a></p>
+]]></description>
       <pubDate>Tue, 13 Jun 2023 04:48:00 GMT</pubDate>
       <link>https://github.com/nodejs/node-gyp/releases/tag/v9.4.0</link>
       <guid>https://github.com/nodejs/node-gyp/releases/tag/v9.4.0</guid>

--- a/scripts/collect-releases.js
+++ b/scripts/collect-releases.js
@@ -1,5 +1,5 @@
 import ghGot from 'gh-got'
-import { buildRFC822Date, composeFeedItem, getFeedContent, overwriteFeedContent, getConfig } from '../utils/index.js'
+import { md2html, buildRFC822Date, composeFeedItem, getFeedContent, overwriteFeedContent, getConfig } from '../utils/index.js'
 
 const { lastCheckTimestamp, releasePaginationLimit, reposPaginationLimit, breakDelimiter } = getConfig()
 
@@ -30,7 +30,7 @@ const releases = await Promise.all(repos.map(async repo => {
 
 const relevantReleases = releases.flat().map(rel => composeFeedItem({
   title: `Released ${rel.repo} ${rel.tag_name}`,
-  description: '',
+  description: `<![CDATA[${md2html(`Released ${rel.repo} ${rel.tag_name} by ${rel.author.login}. [More details](${rel.html_url})`)}]]>`,
   pubDate: buildRFC822Date(rel.published_at),
   link: rel.html_url,
   guid: rel.html_url


### PR DESCRIPTION
### Main changes

- Added Basic description template for releases, ex: `Released nodejs/llhttp release/v8.1.1 by ShogunPanda. [More details](https://github.com/nodejs/llhttp/releases/tag/release/v8.1.1)`
- Updated feed manually to include the updated description for releases

### Context

Some RSS readers might give an error or weird UI when the description is empty, even if this approach is compliance with the RSS spec.

**Generated item with description**
![Captura de pantalla 2023-06-28 a las 15 15 16](https://github.com/nodejs/nodejs-news-feeder/assets/5110813/ef5d09a5-a412-48fc-a1a9-f8ac933b2247)

**Generated item without description**
![Captura de pantalla 2023-06-28 a las 15 15 20](https://github.com/nodejs/nodejs-news-feeder/assets/5110813/8a6165b7-53fd-4520-82ac-a0882bd888fd)



### Changelog

- c68a279 feat: added basic description for releases by @UlisesGascon
- 74b7b91 chore: manual feed update by @UlisesGascon
