### PR TITLE
Added discussions support

### DIFF
--- a/.github/workflows/populate_feed.yml
+++ b/.github/workflows/populate_feed.yml
@@ -35,6 +35,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Collect Discussions (Comments)
+      run: npm run collect:discussions
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
+
     - name: RSS Build
       run: npm run rss:build
 

--- a/config.json
+++ b/config.json
@@ -4,6 +4,12 @@
   "releasePaginationLimit": 10,
   "commentsPaginationLimit": 100,
   "breakDelimiter": "</image>",
+  "discussionsInScope": [
+    {
+      "team": "Node.js Core",
+      "discussionId": "47703"
+    }
+  ],
   "issuesInScope": [
     {
       "team": "News Feeder team",

--- a/feed.xml
+++ b/feed.xml
@@ -15,6 +15,22 @@
       <link>https://feed.nodejs.org/feed.org</link>
     </image>
     <item>
+      <title>Node.js Core update on 2023-04-24 17:45:28</title>
+      <description><![CDATA[<p>Will all announcements be posted in this thread? Maybe we should pin it!</p>
+]]></description>
+      <pubDate>Mon, 24 Apr 2023 19:45:00 GMT</pubDate>
+      <link>https://github.com/orgs/nodejs/discussions/47703#discussioncomment-5711246</link>
+      <guid>https://github.com/orgs/nodejs/discussions/47703#discussioncomment-5711246</guid>
+    </item>
+    <item>
+      <title>Node.js Core update on 2023-05-29 16:17:14</title>
+      <description><![CDATA[<p>@nodejs/collaborators wanted to give everybody an FYI that we've recently reached out to a number of the publications on the list mentioned in https://github.com/nodejs/next-10/issues/110#issue-1108261051 and now and going forward is a good time to start sharing project news in this discussion thread.</p>
+]]></description>
+      <pubDate>Mon, 29 May 2023 18:17:00 GMT</pubDate>
+      <link>https://github.com/orgs/nodejs/discussions/47703#discussioncomment-6030594</link>
+      <guid>https://github.com/orgs/nodejs/discussions/47703#discussioncomment-6030594</guid>
+    </item>
+    <item>
       <title>Uvwasi team update on 2023-06-07 18:05:55</title>
       <description><![CDATA[<p>Node.js main branch updated to include v0.0.18 version os uvwasi</p>
 ]]></description>

--- a/feed.xml
+++ b/feed.xml
@@ -15,22 +15,6 @@
       <link>https://feed.nodejs.org/feed.org</link>
     </image>
     <item>
-      <title>Node.js Core update on 2023-04-24 17:45:28</title>
-      <description><![CDATA[<p>Will all announcements be posted in this thread? Maybe we should pin it!</p>
-]]></description>
-      <pubDate>Mon, 24 Apr 2023 19:45:00 GMT</pubDate>
-      <link>https://github.com/orgs/nodejs/discussions/47703#discussioncomment-5711246</link>
-      <guid>https://github.com/orgs/nodejs/discussions/47703#discussioncomment-5711246</guid>
-    </item>
-    <item>
-      <title>Node.js Core update on 2023-05-29 16:17:14</title>
-      <description><![CDATA[<p>@nodejs/collaborators wanted to give everybody an FYI that we've recently reached out to a number of the publications on the list mentioned in https://github.com/nodejs/next-10/issues/110#issue-1108261051 and now and going forward is a good time to start sharing project news in this discussion thread.</p>
-]]></description>
-      <pubDate>Mon, 29 May 2023 18:17:00 GMT</pubDate>
-      <link>https://github.com/orgs/nodejs/discussions/47703#discussioncomment-6030594</link>
-      <guid>https://github.com/orgs/nodejs/discussions/47703#discussioncomment-6030594</guid>
-    </item>
-    <item>
       <title>Uvwasi team update on 2023-06-07 18:05:55</title>
       <description><![CDATA[<p>Node.js main branch updated to include v0.0.18 version os uvwasi</p>
 ]]></description>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@octokit/graphql": "6.0.1",
         "gh-got": "10.0.0",
         "got": "13.0.0",
         "jsdom": "22.1.0",
@@ -1197,6 +1198,73 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@octokit/endpoint": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-8.0.1.tgz",
+      "integrity": "sha512-tVviBdPuf3kcCiIvXYDJg7NAJrkTh8QEnc+UCybknKdEBCjIi7uQbFX3liQrpk1m5PjwC7fUJg08DYZ4F+l1RQ==",
+      "dependencies": {
+        "@octokit/types": "^10.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-6.0.1.tgz",
+      "integrity": "sha512-d1VbBRGY4cQi7qV2SgoFvshKtqbTsQ135BmDDzoSaRrOPiTqKbfjBcPLeDAmKN/VlGtcRdJqvJ+Vshw16Hx84A==",
+      "dependencies": {
+        "@octokit/request": "^7.0.1",
+        "@octokit/types": "^10.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
+    },
+    "node_modules/@octokit/request": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-7.0.1.tgz",
+      "integrity": "sha512-R227pDk1fuQXuX17LU8ChzFyTOe/myHvvceBF3C/fFath+NlsVkHICOlvEbx+9EgYUl4uDH7VqTby00menlM8Q==",
+      "dependencies": {
+        "@octokit/endpoint": "^8.0.1",
+        "@octokit/request-error": "^4.0.1",
+        "@octokit/types": "^10.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-4.0.2.tgz",
+      "integrity": "sha512-uqwUEmZw3x4I9DGYq9fODVAAvcLsPQv97NRycP6syEFu5916M189VnNBW2zANNwqg3OiligNcAey7P0SET843w==",
+      "dependencies": {
+        "@octokit/types": "^10.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -2214,6 +2282,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -3957,6 +4030,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -5799,7 +5880,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -7157,6 +7237,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
     "node_modules/universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -7456,8 +7541,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "collect:releases": "node scripts/collect-releases.js",
     "collect:issues": "node scripts/collect-issues.js",
+    "collect:discussions": "node scripts/collect-discussions.js",
     "rss:validate": "node scripts/validate.js",
     "rss:build": "node scripts/build.js",
     "rss:format": "node scripts/format.js",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "standard": "17.1.0"
   },
   "dependencies": {
+    "@octokit/graphql": "6.0.1",
     "gh-got": "10.0.0",
     "got": "13.0.0",
     "jsdom": "22.1.0",

--- a/scripts/collect-discussions.js
+++ b/scripts/collect-discussions.js
@@ -1,0 +1,49 @@
+import { graphql } from '@octokit/graphql'
+import { getConfig, composeFeedItem, buildTitleDate, md2html, buildRFC822Date, getFeedContent, overwriteFeedContent } from '../utils/index.js'
+
+const { discussionsInScope, breakDelimiter, lastCheckTimestamp } = getConfig()
+
+const comments = await Promise.all(discussionsInScope.map(async ({ discussionId, team }) => {
+  const { repository } = await graphql(
+    `
+    {
+      repository(name: "node", owner: "nodejs") {
+        discussion(number: ${discussionId}) {
+          comments(last: 100) {
+            edges {
+              node {
+                body
+                publishedAt
+                updatedAt
+                databaseId
+              }
+            }
+          }
+        }
+      }
+    }
+    `,
+    {
+      headers: {
+        authorization: `token ${process.env.GITHUB_TOKEN}`
+      }
+    }
+  )
+
+  return repository.discussion.comments.edges
+    .filter(comment => new Date(comment.node.publishedAt).getTime() > lastCheckTimestamp)
+    .map(comment => ({ ...comment.node, team, discussionId }))
+}))
+
+const relevantComments = comments.flat().map(comment => composeFeedItem({
+  title: `${comment.team} update on ${buildTitleDate(comment.publishedAt)}`,
+  description: `<![CDATA[${md2html(comment.body)}]]>`,
+  pubDate: buildRFC822Date(comment.publishedAt),
+  link: `https://github.com/orgs/nodejs/discussions/${comment.discussionId}#discussioncomment-${comment.databaseId}`,
+  guid: `https://github.com/orgs/nodejs/discussions/${comment.discussionId}#discussioncomment-${comment.databaseId}`
+})).join('')
+
+const feedContent = getFeedContent()
+const [before, after] = feedContent.split(breakDelimiter)
+const updatedFeedContent = `${before}${breakDelimiter}${relevantComments}${after}`
+overwriteFeedContent(updatedFeedContent)


### PR DESCRIPTION
### Main Changes

- Added feed source for Node.js Core team
- Added script to collect discussions' comments using graphql Github API with a new dependency
- Updated pipeline to collect discussions' comments
- Manual feed update to showcase all the comments from the discussion


### Note

I added all the comments in the discussion to showcase the script's functionality. But worth check if we want to finally include them in the feed or not. 

### Changelog

- 05f6559 feat: added feed source for Node.js Core team by @UlisesGascon
- 2713f19 chore: added dependency @octokit/graphql@6.0.1 by @UlisesGascon
- 507e493 feat: added script to collect discussions' comments by @UlisesGascon
- ee756f5 feat: added npm script for collect discussions by @UlisesGascon
- d901eca feat: added step to collect discussions in the pipeline by @UlisesGascon
- 04751cf chore: manual feed update by @UlisesGascon