### PR TITLE
add support for retrospective

### DIFF
--- a/.github/workflows/populate_feed.yml
+++ b/.github/workflows/populate_feed.yml
@@ -39,6 +39,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
 
+    - name: Collect Retrospective
+      run: npm run collect:retrospective
+
     - name: RSS Build
       run: npm run rss:build
 

--- a/config.json
+++ b/config.json
@@ -3,6 +3,10 @@
   "reposPaginationLimit": 250,
   "releasePaginationLimit": 10,
   "commentsPaginationLimit": 100,
+  "retrospective": {
+    "lastDay": "2023-10-15",
+    "nextDay": "2023-10-22"
+  },
   "breakDelimiter": "</image>",
   "discussionsInScope": [
     {

--- a/feed.xml
+++ b/feed.xml
@@ -15,6 +15,13 @@
       <link>https://github.com/nodejs/nodejs-news-feeder</link>
     </image>
     <item>
+      <title>Retrospective for nodejs from 2023-10-15 to 2023-10-22</title>
+      <description><![CDATA[<p>Reporting on 35 Issues from 29 authors, 65 Pull Requests from 33 authors, and 9 Discussions from 7 authors.</p>]]></description>
+      <pubDate>Sun, 22 Oct 2023 08:00:00 GMT</pubDate>
+      <link>https://github.com/cutenode/retro-weekly/blob/main/retros/2023-10-22.md</link>
+      <guid>https://github.com/cutenode/retro-weekly/blob/main/retros/2023-10-22.md</guid>
+    </item>
+    <item>
       <title>Released nodejs/corepack v0.23.0</title>
       <description><![CDATA[<p>Released nodejs/corepack v0.23.0 by github-actions[bot]. <a href="https://github.com/nodejs/corepack/releases/tag/v0.23.0">More details</a></p>
 ]]></description>

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,4 @@
 module.exports = {
-  preset: 'ts-jest',
   testEnvironment: 'jest-environment-node',
   transform: {},
   transformIgnorePatterns: ['<rootDir>/node_modules/']

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "collect:releases": "node scripts/collect-releases.js",
     "collect:issues": "node scripts/collect-issues.js",
     "collect:discussions": "node scripts/collect-discussions.js",
+    "collect:retrospective": "node scripts/collect-retrospective.js",
     "rss:validate": "node scripts/validate.js",
     "rss:build": "node scripts/build.js",
     "rss:format": "node scripts/format.js",

--- a/scripts/collect-retrospective.js
+++ b/scripts/collect-retrospective.js
@@ -1,0 +1,36 @@
+import got from 'got'
+import { buildRFC822Date, overwriteConfig, composeFeedItem, getFeedContent, overwriteFeedContent, getConfig, generateRetroRequestUrl, parseRetrospectiveContent, generateRetroUIUrl } from '../utils/index.js'
+
+// Collect new retrospective
+const { retrospective: currentConfig, breakDelimiter } = getConfig()
+const url = generateRetroRequestUrl(currentConfig.nextDay)
+
+try {
+  const content = await got(url).text()
+  const data = parseRetrospectiveContent(content)
+  const retrospective = composeFeedItem({
+    title: data.title,
+    description: `<![CDATA[<p>${data.description}</p>]]>`,
+    pubDate: buildRFC822Date(data.lastDay),
+    link: generateRetroUIUrl(data.lastDay),
+    guid: generateRetroUIUrl(data.lastDay)
+  })
+  // Add the new item to the feed
+  const feedContent = getFeedContent()
+  const [before, after] = feedContent.split(breakDelimiter)
+  const updatedFeedContent = `${before}${breakDelimiter}${retrospective}${after}`
+  overwriteFeedContent(updatedFeedContent)
+
+  // Overwrite config with new dates
+  const config = getConfig()
+  overwriteConfig({
+    ...config,
+    retrospective: {
+      lastDay: data.lastDay,
+      nextDay: data.nextDay
+    }
+  })
+} catch (error) {
+  console.log("Retrospective not found or generated and error, so we're not updating the feed.")
+  console.log("Configuration for the retrospective won't be updated either.")
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -4,6 +4,7 @@ import { createHash } from 'crypto'
 import * as remark from 'remark'
 import remarkHtml from 'remark-html'
 
+const dateRegex = /(\d*-\d*-\d*)/gm
 const xmlFile = join(process.cwd(), 'feed.xml')
 const configFile = join(process.cwd(), 'config.json')
 
@@ -73,4 +74,19 @@ export function buildRFC822Date (dateString) {
 
   // Wed, 02 Oct 2002 13:00:00 GMT
   return `${day}, ${dayNumber} ${month} ${year} ${time} ${timezone}`
+}
+
+export function generateRetroRequestUrl (dateString) {
+  return `https://raw.githubusercontent.com/cutenode/retro-weekly/main/retros/${dateString}.md`
+}
+
+export function generateRetroUIUrl (dateString) {
+  return `https://github.com/cutenode/retro-weekly/blob/main/retros/${dateString}.md`
+}
+
+export function parseRetrospectiveContent (data) {
+  const [rawTitle, , description] = data.split('\n')
+  const title = rawTitle.replace('# ', '').replaceAll('`', '').trim()
+  const dates = title.split(dateRegex)
+  return { title, description, lastDay: dates[1], nextDay: dates[3] }
 }


### PR DESCRIPTION
### Main changes

This PR will include the Top threads of the week/month for the Node.js org in Github by including a link to the last report available in https://github.com/cutenode/retro-weekly (cc: @bnb @wesleytodd)

**How it works**

- 1. Checks the config file to get the reference for report (date)
- 2. Try to reach the URL and get the Markdown in raw format like https://raw.githubusercontent.com/cutenode/retro-weekly/main/retros/2023-10-22.md
- 3. Extract the relevant data (title, description, fromDate y toDate) using basic string manipulation.
- 4. Generate a valid feed item like:
```xml
  <item>
    <title>Retrospective for nodejs from 2023-10-22 to 2023-10-29</title>
    <description><![CDATA[<p>Reporting on 35 Issues from 29 authors, 65 Pull Requests from 33 authors, and 9 Discussions from 7 authors.</p>]]></description>
    <pubDate>Sun, 22 Oct 2023 02:00:00 BST</pubDate>
    <link>https://github.com/cutenode/retro-weekly/blob/main/retros/2023-10-22.md</link>
    <guid>https://github.com/cutenode/retro-weekly/blob/main/retros/2023-10-22.md</guid>
  </item>
```
- 5. Add the new item in the feed 
- 6. Save the new dates in the config
 
### Context

- Close https://github.com/nodejs/nodejs-news-feeder/issues/42
- Related https://github.com/nodejs/next-10/issues/231#issuecomment-1735689359